### PR TITLE
feat(startup): add startup prompt feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ If you need to use a specific model or require a higher request capacity, you ca
 
 For other authentication methods, including Google Workspace accounts, see the [authentication](./docs/cli/authentication.md) guide.
 
+## Startup Prompt
+
+You can provide a prompt that will be automatically run when the application starts. This is useful for automating tasks or setting up your environment.
+
+To use the startup prompt, add the `--startup-prompt` flag to the `gemini` command:
+
+```bash
+gemini --startup-prompt "what is the capitol of France"
+```
+
 ## Examples
 
 Once the CLI is running, you can start interacting with Gemini from your shell.

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -12,6 +12,7 @@ import { vi } from 'vitest';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useCompletion } from '../hooks/useCompletion.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
+import React from 'react';
 
 vi.mock('../hooks/useShellHistory.js');
 vi.mock('../hooks/useCompletion.js');
@@ -187,33 +188,30 @@ describe('InputPrompt', () => {
   });
 
   it('should only submit the startup prompt once', async () => {
-    const startupProps = {
-      ...props,
-      startupPrompt: 'startup',
-      isInitialized: false,
+    const TestComponent = () => {
+      const [isInitialized, setIsInitialized] = React.useState(false);
+      React.useEffect(() => {
+        setTimeout(() => {
+          setIsInitialized(true);
+        }, 10);
+      }, []);
+
+      return (
+        <InputPrompt
+          {...props}
+          startupPrompt="startup"
+          isInitialized={isInitialized}
+        />
+      );
     };
-    const { rerender, unmount } = render(<InputPrompt {...startupProps} />);
 
-    await wait();
+    const { unmount } = render(<TestComponent />);
 
-    // Prompt should not be submitted initially because isInitialized is false
-    expect(startupProps.onSubmit).not.toHaveBeenCalled();
-    expect(startupProps.onStartupPromptHandled).not.toHaveBeenCalled();
+    await wait(100);
 
-    // Re-render with isInitialized = true
-    rerender(<InputPrompt {...startupProps} isInitialized={true} />);
-    await wait();
-
-    expect(startupProps.onSubmit).toHaveBeenCalledTimes(1);
-    expect(startupProps.onSubmit).toHaveBeenCalledWith('startup');
-    expect(startupProps.onStartupPromptHandled).toHaveBeenCalledTimes(1);
-
-    // Re-render again, should not trigger again
-    rerender(<InputPrompt {...startupProps} isInitialized={true} />);
-    await wait();
-
-    expect(startupProps.onSubmit).toHaveBeenCalledTimes(1);
-    expect(startupProps.onStartupPromptHandled).toHaveBeenCalledTimes(1);
+    expect(props.onSubmit).toHaveBeenCalledTimes(1);
+    expect(props.onSubmit).toHaveBeenCalledWith('startup');
+    expect(props.onStartupPromptHandled).toHaveBeenCalledTimes(1);
 
     unmount();
   });


### PR DESCRIPTION
This PR introduces the startup prompt feature, which allows a user to provide a prompt that will be automatically run when the application starts.

This PR also includes a fix for an infinite loop that was occurring during the startup prompt injection.

### How to use the startup prompt feature

You can provide a prompt that will be automatically run when the application starts. This is useful for automating tasks or setting up your environment.

To use the startup prompt, add the  flag to the ]2; Gemini - gemini-cli Loading extension: CodeMind (version: 1.0.0)
Loaded 18 patterns from /usr/local/google/home/dhalem/cli/gemini-cli/.gitignore
MCP STDERR (CodeMind): # Python Launcher: Imported google3.learning.sre.training.python_profiling.import_profiler triggered by sentinel

MCP STDERR (CodeMind):                     INFO     Process id 2745780                       app.py:279

MCP STDERR (CodeMind):                     INFO     Current working directory                app.py:281
                             /usr/local/google/home/dhalem/cli/gemini           
                             -cli                                               

MCP STDERR (CodeMind):                     INFO     Built on Wed Jun 25 01:42:55 2025        app.py:284
                             (1750815775)                                       
                             Built by                                           
                             rbex-enqueue-targets@jfva2.prod.google.c           
                             om:/google/src/cloud/buildrabbit-usernam           
                             e/buildrabbit-client/google3                       
                             Built as                                           
                             //gdm/codeai/codemind/cli:server                   
                             Build ID:                                          
                             adc74029-8424-440d-92e1-3f9de49641c2               
                             Built from changelist 775422448 in a               
                             mint client based on //depot/google3               
                             Build label:                                       
                             codemind-mcp-server.glinux_20250624.03_p           
                             0                                                  
                             Build platform:                                    
                             gcc-4.X.Y-crosstool-v18-llvm-grtev4-k8.k           
                             8                                                  
                             Build tool: Blaze, release                         
                             blaze-2025.06.16-2 (mainline @771801095)           
                             Built with par options []                          
                             Currently running under Python 3.12.11:            
                             embedded.                                          
                                                                                

MCP STDERR (CodeMind):                     INFO     Command line arguments:                  app.py:287

MCP STDERR (CodeMind):                     INFO     argv[0]:                                 app.py:289
                             '/google/bin/releases/codemind-mcp-serve           
                             r/server.par'                                      

MCP STDERR (CodeMind):                     INFO     Processing request of type            server.py:523
                             ListToolsRequest                                   

]2; command:

```bash
gemini --startup-prompt "what is the capitol of France"
```